### PR TITLE
Fixed Cloudsponge AOL imports

### DIFF
--- a/src/main/java/com/cloudsponge/ContactsService.java
+++ b/src/main/java/com/cloudsponge/ContactsService.java
@@ -34,8 +34,8 @@ public abstract class ContactsService<T extends ImportResponse> implements
 	public static final ContactsService<UserConsent> YAHOO =
 			new UserConsentContactsService("YAHOO");
 
-	public static final ContactsService<ImportResponse> AOL =
-			new AuthenticationContactsService("AOL");
+	public static final ContactsService<UserConsent> AOL =
+			new UserConsentContactsService("AOL");
 
 	public static final ContactsService<ImportResponse> PLAXO =
 			new AuthenticationContactsService("PLAXO");


### PR DESCRIPTION
AOL imports must be done with UserConsent and not with ImportResponse, like it is said in cloudsponge documentation (http://www.cloudsponge.com/developer/api-diy#step1)
